### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/library/varnishadm.py
+++ b/library/varnishadm.py
@@ -61,9 +61,9 @@ def get_state(module, secret, backend, name):
     args = ''
 
     if name:
-        args += ' -n %s ' % name
+        args += ' -n {0!s} '.format(name)
 
-    cmd = "varnishadm -S '%s' %s backend.list %s" % (secret, args, backend)
+    cmd = "varnishadm -S '{0!s}' {1!s} backend.list {2!s}".format(secret, args, backend)
 
     (rc, out, err) = module.run_command(cmd)
     if rc:
@@ -85,14 +85,14 @@ def change_state(module, secret, state, backend, name):
     args = ''
 
     if name:
-        args += ' -n %s ' % name
+        args += ' -n {0!s} '.format(name)
 
     current_state = get_state(module, secret, backend, name)
 
     if state == current_state:
         return module.exit_json(changed=False)
 
-    cmd = "varnishadm -S '%s' %s backend.set_health %s %s" % (secret, args, backend, state)
+    cmd = "varnishadm -S '{0!s}' {1!s} backend.set_health {2!s} {3!s}".format(secret, args, backend, state)
 
     (rc, out, err) = module.run_command(cmd)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:sidick:ansible_varnishadm?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:sidick:ansible_varnishadm?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
